### PR TITLE
feat: add cmd dumps

### DIFF
--- a/ra_dump.go
+++ b/ra_dump.go
@@ -1,0 +1,702 @@
+package ra
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// GenerateDump creates a comprehensive dump of the command structure and parsing context
+func (c *Cmd) GenerateDump(args []string, opts ...ParseOpt) string {
+	return c.generateDump(args, opts...)
+}
+
+// generateDump creates a comprehensive dump of the command structure and parsing context
+func (c *Cmd) generateDump(args []string, opts ...ParseOpt) string {
+	return c.generateDumpWithDepth(args, 0, opts...)
+}
+
+// generateDumpWithDepth creates a comprehensive dump with recursion depth tracking
+func (c *Cmd) generateDumpWithDepth(args []string, depth int, opts ...ParseOpt) string {
+	var sb strings.Builder
+
+	// Root command header
+	if depth == 0 {
+		sb.WriteString(GreenBoldS("Ra Command Dump") + "\n")
+		sb.WriteString(strings.Repeat("=", 50) + "\n\n")
+	} else {
+		// Subcommand header with indentation
+		indent := strings.Repeat("  ", depth)
+		sb.WriteString(fmt.Sprintf("%s%s (%s)\n", indent, GreenBoldS("Subcommand Dump"), BoldS(c.name)))
+		sb.WriteString(fmt.Sprintf("%s%s\n\n", indent, strings.Repeat("-", 30)))
+	}
+
+	// Generate sections with appropriate indentation
+	sb.WriteString(c.generateParseConfigSectionWithIndent(depth, opts...))
+	sb.WriteString(c.generateCommandInfoSectionWithIndent(depth))
+	if depth == 0 { // Only show arguments for root command
+		sb.WriteString(c.generateArgumentsToParseSection(args))
+	}
+	sb.WriteString(c.generateFlagsStructureSectionWithIndent(depth))
+	if depth == 0 { // Only show environment for root command
+		sb.WriteString(c.generateEnvironmentSection())
+	}
+
+	// Recursively dump subcommands
+	if len(c.subCmds) > 0 {
+		// Add separator before subcommands
+		if depth == 0 {
+			sb.WriteString("\n" + GreenBoldS("Subcommand Details:") + "\n")
+			sb.WriteString(strings.Repeat("=", 50) + "\n\n")
+		}
+
+		// Get sorted subcommand names for consistent output
+		names := make([]string, 0, len(c.subCmds))
+		for name := range c.subCmds {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		for _, name := range names {
+			subCmd := c.subCmds[name]
+			subDump := subCmd.generateDumpWithDepth(nil, depth+1, opts...)
+			sb.WriteString(subDump)
+			if name != names[len(names)-1] { // Add separator between subcommands
+				sb.WriteString("\n")
+			}
+		}
+	}
+
+	return sb.String()
+}
+
+// generateParseConfigSection generates information about parse configuration
+func (c *Cmd) generateParseConfigSection(opts ...ParseOpt) string {
+	return c.generateParseConfigSectionWithIndent(0, opts...)
+}
+
+// generateParseConfigSectionWithIndent generates parse config section with indentation
+func (c *Cmd) generateParseConfigSectionWithIndent(depth int, opts ...ParseOpt) string {
+	var sb strings.Builder
+	indent := strings.Repeat("  ", depth)
+
+	sb.WriteString(fmt.Sprintf("%s%s\n", indent, GreenBoldS("Parse Configuration:")))
+
+	// Build the config to see what options are set
+	cfg := &parseCfg{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	sb.WriteString(fmt.Sprintf("%s  Ignore Unknown: %s\n", indent, BoldS(fmt.Sprintf("%t", cfg.ignoreUnknown))))
+	sb.WriteString(fmt.Sprintf("%s  Dump Enabled: %s\n", indent, BoldS(fmt.Sprintf("%t", cfg.dump))))
+	sb.WriteString("\n")
+
+	return sb.String()
+}
+
+// generateCommandInfoSection generates information about the command structure
+func (c *Cmd) generateCommandInfoSection() string {
+	return c.generateCommandInfoSectionWithIndent(0)
+}
+
+// generateCommandInfoSectionWithIndent generates command info section with indentation
+func (c *Cmd) generateCommandInfoSectionWithIndent(depth int) string {
+	var sb strings.Builder
+	indent := strings.Repeat("  ", depth)
+
+	sb.WriteString(fmt.Sprintf("%s%s\n", indent, GreenBoldS("Command Information:")))
+
+	sb.WriteString(fmt.Sprintf("%s  Name: %s\n", indent, BoldS(c.name)))
+	if c.description != "" {
+		sb.WriteString(fmt.Sprintf("%s  Description: %s\n", indent, BoldS(c.description)))
+	} else {
+		sb.WriteString(fmt.Sprintf("%s  Description: %s\n", indent, CyanS("<not set>")))
+	}
+
+	sb.WriteString(fmt.Sprintf("%s  Help Enabled: %s\n", indent, BoldS(fmt.Sprintf("%t", c.helpEnabled))))
+	sb.WriteString(fmt.Sprintf("%s  Auto Help on No Args: %s\n", indent, BoldS(fmt.Sprintf("%t", c.autoHelpOnNoArgs))))
+	sb.WriteString(fmt.Sprintf("%s  Exclude Name from Usage: %s\n", indent, BoldS(fmt.Sprintf("%t", c.excludeNameFromUsage))))
+
+	if c.customUsage != nil {
+		sb.WriteString(fmt.Sprintf("%s  Custom Usage Function: %s\n", indent, BoldS("set")))
+	} else {
+		sb.WriteString(fmt.Sprintf("%s  Custom Usage Function: %s\n", indent, CyanS("not set")))
+	}
+
+	if c.parseHooks != nil {
+		if c.parseHooks.PostParse != nil {
+			sb.WriteString(fmt.Sprintf("%s  PostParse Hook: %s\n", indent, BoldS("set")))
+		} else {
+			sb.WriteString(fmt.Sprintf("%s  PostParse Hook: %s\n", indent, CyanS("not set")))
+		}
+	} else {
+		sb.WriteString(fmt.Sprintf("%s  PostParse Hook: %s\n", indent, CyanS("not set")))
+	}
+
+	// Subcommands
+	if len(c.subCmds) > 0 {
+		sb.WriteString(fmt.Sprintf("%s  Subcommands (%d): %s\n", indent, len(c.subCmds), BoldS(c.getSubcommandNames())))
+	} else {
+		sb.WriteString(fmt.Sprintf("%s  Subcommands: %s\n", indent, CyanS("none")))
+	}
+
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// generateArgumentsToParseSection generates information about the arguments provided for parsing
+func (c *Cmd) generateArgumentsToParseSection(args []string) string {
+	var sb strings.Builder
+	sb.WriteString(GreenBoldS("Arguments to Parse:") + "\n")
+
+	if len(args) == 0 {
+		sb.WriteString("  " + CyanS("<no arguments>") + "\n")
+	} else {
+		for i, arg := range args {
+			sb.WriteString(fmt.Sprintf("  [%d]: %s\n", i, BoldS(fmt.Sprintf("%q", arg))))
+		}
+	}
+
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// generateFlagsStructureSection generates comprehensive information about all flags
+func (c *Cmd) generateFlagsStructureSection() string {
+	return c.generateFlagsStructureSectionWithIndent(0)
+}
+
+// generateFlagsStructureSectionWithIndent generates flags structure section with indentation
+func (c *Cmd) generateFlagsStructureSectionWithIndent(depth int) string {
+	var sb strings.Builder
+	indent := strings.Repeat("  ", depth)
+
+	sb.WriteString(fmt.Sprintf("%s%s\n", indent, GreenBoldS("Flags Structure:")))
+
+	// Flag counts
+	totalFlags := len(c.flags)
+	positionalFlags := len(c.positional)
+	nonPositionalFlags := len(c.nonPositional)
+	globalFlags := len(c.globalFlags)
+
+	sb.WriteString(fmt.Sprintf("%s  Total Flags: %s\n", indent, BoldS(fmt.Sprintf("%d", totalFlags))))
+	sb.WriteString(fmt.Sprintf("%s  Positional Flags: %s\n", indent, BoldS(fmt.Sprintf("%d", positionalFlags))))
+	sb.WriteString(fmt.Sprintf("%s  Non-Positional Flags: %s\n", indent, BoldS(fmt.Sprintf("%d", nonPositionalFlags))))
+	sb.WriteString(fmt.Sprintf("%s  Global Flags: %s\n", indent, BoldS(fmt.Sprintf("%d", globalFlags))))
+	sb.WriteString("\n")
+
+	// Positional flags
+	if len(c.positional) > 0 {
+		sb.WriteString(fmt.Sprintf("%s%s\n", indent, GreenBoldS("  Positional Flags (in order):")))
+		for i, name := range c.positional {
+			flag := c.flags[name]
+			sb.WriteString(fmt.Sprintf("%s    [%d] %s\n", indent, i, c.formatFlagForDump(name, flag)))
+		}
+		sb.WriteString("\n")
+	}
+
+	// Non-positional flags
+	if len(c.nonPositional) > 0 {
+		sb.WriteString(fmt.Sprintf("%s%s\n", indent, GreenBoldS("  Non-Positional Flags:")))
+		for _, name := range c.nonPositional {
+			flag := c.flags[name]
+			sb.WriteString(fmt.Sprintf("%s    %s\n", indent, c.formatFlagForDump(name, flag)))
+		}
+		sb.WriteString("\n")
+	}
+
+	// Global flags
+	if len(c.globalFlags) > 0 {
+		sb.WriteString(fmt.Sprintf("%s%s\n", indent, GreenBoldS("  Global Flags:")))
+		for _, name := range c.globalFlags {
+			if flag, exists := c.flags[name]; exists {
+				sb.WriteString(fmt.Sprintf("%s    %s\n", indent, c.formatFlagForDump(name, flag)))
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	// Flag conflicts and shadows
+	if len(c.overriddenGlobalFlags) > 0 || len(c.shadowedShortFlags) > 0 || len(c.shadowedNameFlags) > 0 {
+		sb.WriteString(fmt.Sprintf("%s%s\n", indent, GreenBoldS("  Flag Conflicts:")))
+
+		if len(c.overriddenGlobalFlags) > 0 {
+			sb.WriteString(fmt.Sprintf("%s    Overridden Global Flags:\n", indent))
+			for name := range c.overriddenGlobalFlags {
+				sb.WriteString(fmt.Sprintf("%s      %s\n", indent, BoldS(name)))
+			}
+		}
+
+		if len(c.shadowedShortFlags) > 0 {
+			sb.WriteString(fmt.Sprintf("%s    Shadowed Short Flags:\n", indent))
+			for name := range c.shadowedShortFlags {
+				sb.WriteString(fmt.Sprintf("%s      %s\n", indent, BoldS(name)))
+			}
+		}
+
+		if len(c.shadowedNameFlags) > 0 {
+			sb.WriteString(fmt.Sprintf("%s    Shadowed Name Flags:\n", indent))
+			for name := range c.shadowedNameFlags {
+				sb.WriteString(fmt.Sprintf("%s      %s\n", indent, BoldS(name)))
+			}
+		}
+
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// generateEnvironmentSection generates information about the environment
+func (c *Cmd) generateEnvironmentSection() string {
+	var sb strings.Builder
+	sb.WriteString(GreenBoldS("Environment:") + "\n")
+
+	// Check RA_COLOR environment variable
+	raColor := os.Getenv("RA_COLOR")
+	if raColor != "" {
+		sb.WriteString(fmt.Sprintf("  RA_COLOR: %s\n", BoldS(raColor)))
+	} else {
+		sb.WriteString(fmt.Sprintf("  RA_COLOR: %s\n", CyanS("not set")))
+	}
+
+	return sb.String()
+}
+
+// Helper functions
+
+// getSubcommandNames returns a comma-separated list of subcommand names
+func (c *Cmd) getSubcommandNames() string {
+	names := make([]string, 0, len(c.subCmds))
+	for name := range c.subCmds {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+// formatFlagForDump formats a flag with comprehensive details for dump output
+func (c *Cmd) formatFlagForDump(name string, flag any) string {
+	base := getBaseFlag(flag)
+	if base == nil {
+		return fmt.Sprintf("%s: %s", BoldS(name), CyanS("unknown type"))
+	}
+
+	var parts []string
+
+	// Name and short
+	if base.Short != "" {
+		parts = append(parts, fmt.Sprintf("%s (-%s)", BoldS(name), BoldS(base.Short)))
+	} else {
+		parts = append(parts, BoldS(name))
+	}
+
+	// Type with constraints
+	flagType := c.getFlagTypeForDump(flag)
+	parts = append(parts, fmt.Sprintf("type:%s", CyanS(flagType)))
+
+	// Required/Optional with default value
+	if base.Optional {
+		parts = append(parts, CyanS("optional"))
+	} else {
+		hasDefault := c.flagHasDefault(flag)
+		if hasDefault {
+			defaultVal := c.getFlagDefaultValue(flag)
+			parts = append(parts, fmt.Sprintf("%s %s", CyanS("optional"), CyanS(fmt.Sprintf("(default:%s)", defaultVal))))
+		} else {
+			parts = append(parts, CyanS("required"))
+		}
+	}
+
+	// Current value
+	currentVal := c.getFlagCurrentValue(flag)
+	if currentVal != "" {
+		parts = append(parts, fmt.Sprintf("current:%s", currentVal))
+	}
+
+	// Configured status
+	if c.configured[name] {
+		parts = append(parts, "configured")
+	}
+
+	// Relational constraints
+	requires := c.getFlagRequires(flag)
+	if len(requires) > 0 {
+		parts = append(parts, fmt.Sprintf("requires:[%s]", strings.Join(requires, ",")))
+	}
+
+	excludes := c.getFlagExcludes(flag)
+	if len(excludes) > 0 {
+		parts = append(parts, fmt.Sprintf("excludes:[%s]", strings.Join(excludes, ",")))
+	}
+
+	// Flag properties
+	var flags []string
+	if base.Hidden {
+		flags = append(flags, "hidden")
+	}
+	if base.HiddenInShortHelp {
+		flags = append(flags, "hidden-in-short")
+	}
+	if base.PositionalOnly {
+		flags = append(flags, "positional-only")
+	}
+	if base.FlagOnly {
+		flags = append(flags, "flag-only")
+	}
+	if base.BypassValidation {
+		flags = append(flags, "bypass-validation")
+	}
+
+	if len(flags) > 0 {
+		parts = append(parts, fmt.Sprintf("flags:[%s]", strings.Join(flags, ",")))
+	}
+
+	// Usage
+	if base.Usage != "" {
+		parts = append(parts, fmt.Sprintf("usage:%s", fmt.Sprintf("%q", base.Usage)))
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// getFlagTypeForDump returns a string representation of the flag type for dump output
+func (c *Cmd) getFlagTypeForDump(flag any) string {
+	switch f := flag.(type) {
+	case *BoolFlag:
+		return "bool"
+	case *StringFlag:
+		result := "string"
+		if f.EnumConstraint != nil {
+			result += fmt.Sprintf("{%s}", strings.Join(*f.EnumConstraint, ","))
+		}
+		if f.RegexConstraint != nil {
+			result += fmt.Sprintf("~%s", f.RegexConstraint.String())
+		}
+		return result
+	case *IntFlag:
+		result := "int"
+		if f.min != nil || f.max != nil {
+			var minStr, maxStr string
+			if f.min != nil {
+				minStr = fmt.Sprintf("%d", *f.min)
+				if f.minInclusive != nil && !*f.minInclusive {
+					minStr = "(" + minStr
+				} else {
+					minStr = "[" + minStr
+				}
+			} else {
+				minStr = "(-∞"
+			}
+			if f.max != nil {
+				maxStr = fmt.Sprintf("%d", *f.max)
+				if f.maxInclusive != nil && !*f.maxInclusive {
+					maxStr = maxStr + ")"
+				} else {
+					maxStr = maxStr + "]"
+				}
+			} else {
+				maxStr = "+∞)"
+			}
+			result += fmt.Sprintf("%s,%s", minStr, maxStr)
+		}
+		return result
+	case *Int64Flag:
+		result := "int64"
+		if f.min != nil || f.max != nil {
+			var minStr, maxStr string
+			if f.min != nil {
+				minStr = fmt.Sprintf("%d", *f.min)
+				if f.minInclusive != nil && !*f.minInclusive {
+					minStr = "(" + minStr
+				} else {
+					minStr = "[" + minStr
+				}
+			} else {
+				minStr = "(-∞"
+			}
+			if f.max != nil {
+				maxStr = fmt.Sprintf("%d", *f.max)
+				if f.maxInclusive != nil && !*f.maxInclusive {
+					maxStr = maxStr + ")"
+				} else {
+					maxStr = maxStr + "]"
+				}
+			} else {
+				maxStr = "+∞)"
+			}
+			result += fmt.Sprintf("%s,%s", minStr, maxStr)
+		}
+		return result
+	case *Float64Flag:
+		result := "float64"
+		if f.min != nil || f.max != nil {
+			var minStr, maxStr string
+			if f.min != nil {
+				minStr = fmt.Sprintf("%g", *f.min)
+				if f.minInclusive != nil && !*f.minInclusive {
+					minStr = "(" + minStr
+				} else {
+					minStr = "[" + minStr
+				}
+			} else {
+				minStr = "(-∞"
+			}
+			if f.max != nil {
+				maxStr = fmt.Sprintf("%g", *f.max)
+				if f.maxInclusive != nil && !*f.maxInclusive {
+					maxStr = maxStr + ")"
+				} else {
+					maxStr = maxStr + "]"
+				}
+			} else {
+				maxStr = "+∞)"
+			}
+			result += fmt.Sprintf("%s,%s", minStr, maxStr)
+		}
+		return result
+	case *StringSliceFlag:
+		result := "[]string"
+		if f.Variadic {
+			result += "(variadic)"
+		}
+		if f.Separator != nil {
+			result += fmt.Sprintf(" sep:%q", *f.Separator)
+		}
+		return result
+	case *IntSliceFlag:
+		result := "[]int"
+		if f.Variadic {
+			result += "(variadic)"
+		}
+		if f.Separator != nil {
+			result += fmt.Sprintf(" sep:%q", *f.Separator)
+		}
+		return result
+	case *Int64SliceFlag:
+		result := "[]int64"
+		if f.Variadic {
+			result += "(variadic)"
+		}
+		if f.Separator != nil {
+			result += fmt.Sprintf(" sep:%q", *f.Separator)
+		}
+		return result
+	case *Float64SliceFlag:
+		result := "[]float64"
+		if f.Variadic {
+			result += "(variadic)"
+		}
+		if f.Separator != nil {
+			result += fmt.Sprintf(" sep:%q", *f.Separator)
+		}
+		return result
+	case *BoolSliceFlag:
+		result := "[]bool"
+		if f.Variadic {
+			result += "(variadic)"
+		}
+		if f.Separator != nil {
+			result += fmt.Sprintf(" sep:%q", *f.Separator)
+		}
+		return result
+	}
+	return "unknown"
+}
+
+// getFlagDefaultValue returns the default value of a flag as a string
+func (c *Cmd) getFlagDefaultValue(flag any) string {
+	switch f := flag.(type) {
+	case *BoolFlag:
+		if f.Default != nil {
+			return fmt.Sprintf("%t", *f.Default)
+		}
+		return "false"
+	case *StringFlag:
+		if f.Default != nil {
+			return fmt.Sprintf("%q", *f.Default)
+		}
+	case *IntFlag:
+		if f.Default != nil {
+			return fmt.Sprintf("%d", *f.Default)
+		}
+	case *Int64Flag:
+		if f.Default != nil {
+			return fmt.Sprintf("%d", *f.Default)
+		}
+	case *Float64Flag:
+		if f.Default != nil {
+			return fmt.Sprintf("%g", *f.Default)
+		}
+	case *StringSliceFlag:
+		if f.Default != nil {
+			return fmt.Sprintf("%q", *f.Default)
+		}
+		return "[]"
+	case *IntSliceFlag:
+		if f.Default != nil {
+			return fmt.Sprintf("%v", *f.Default)
+		}
+		return "[]"
+	case *Int64SliceFlag:
+		if f.Default != nil {
+			return fmt.Sprintf("%v", *f.Default)
+		}
+		return "[]"
+	case *Float64SliceFlag:
+		if f.Default != nil {
+			return fmt.Sprintf("%v", *f.Default)
+		}
+		return "[]"
+	case *BoolSliceFlag:
+		if f.Default != nil {
+			return fmt.Sprintf("%v", *f.Default)
+		}
+		return "[]"
+	}
+	return "none"
+}
+
+// getFlagCurrentValue returns the current value of a flag as a string, only if interesting
+func (c *Cmd) getFlagCurrentValue(flag any) string {
+	switch f := flag.(type) {
+	case *BoolFlag:
+		// Only show bool current value if it's true or if it has an explicit default
+		if f.Value != nil && (*f.Value || (f.Default != nil && *f.Default)) {
+			return fmt.Sprintf("%t", *f.Value)
+		}
+	case *StringFlag:
+		if f.Value != nil && *f.Value != "" {
+			return fmt.Sprintf("%q", *f.Value)
+		}
+	case *IntFlag:
+		if f.Value != nil && *f.Value != 0 {
+			return fmt.Sprintf("%d", *f.Value)
+		}
+	case *Int64Flag:
+		if f.Value != nil && *f.Value != 0 {
+			return fmt.Sprintf("%d", *f.Value)
+		}
+	case *Float64Flag:
+		if f.Value != nil && *f.Value != 0 {
+			return fmt.Sprintf("%g", *f.Value)
+		}
+	case *StringSliceFlag:
+		if f.Value != nil && len(*f.Value) > 0 {
+			return fmt.Sprintf("%q", *f.Value)
+		}
+	case *IntSliceFlag:
+		if f.Value != nil && len(*f.Value) > 0 {
+			return fmt.Sprintf("%v", *f.Value)
+		}
+	case *Int64SliceFlag:
+		if f.Value != nil && len(*f.Value) > 0 {
+			return fmt.Sprintf("%v", *f.Value)
+		}
+	case *Float64SliceFlag:
+		if f.Value != nil && len(*f.Value) > 0 {
+			return fmt.Sprintf("%v", *f.Value)
+		}
+	case *BoolSliceFlag:
+		if f.Value != nil && len(*f.Value) > 0 {
+			return fmt.Sprintf("%v", *f.Value)
+		}
+	}
+	return ""
+}
+
+// getFlagRequires returns the requires constraint of a flag
+func (c *Cmd) getFlagRequires(flag any) []string {
+	switch f := flag.(type) {
+	case *BoolFlag:
+		if f.Requires != nil {
+			return *f.Requires
+		}
+	case *StringFlag:
+		if f.Requires != nil {
+			return *f.Requires
+		}
+	case *IntFlag:
+		if f.Requires != nil {
+			return *f.Requires
+		}
+	case *Int64Flag:
+		if f.Requires != nil {
+			return *f.Requires
+		}
+	case *Float64Flag:
+		if f.Requires != nil {
+			return *f.Requires
+		}
+	case *StringSliceFlag:
+		if f.Requires != nil {
+			return *f.Requires
+		}
+	case *IntSliceFlag:
+		if f.Requires != nil {
+			return *f.Requires
+		}
+	case *Int64SliceFlag:
+		if f.Requires != nil {
+			return *f.Requires
+		}
+	case *Float64SliceFlag:
+		if f.Requires != nil {
+			return *f.Requires
+		}
+	case *BoolSliceFlag:
+		if f.Requires != nil {
+			return *f.Requires
+		}
+	}
+	return nil
+}
+
+// getFlagExcludes returns the excludes constraint of a flag
+func (c *Cmd) getFlagExcludes(flag any) []string {
+	switch f := flag.(type) {
+	case *BoolFlag:
+		if f.Excludes != nil {
+			return *f.Excludes
+		}
+	case *StringFlag:
+		if f.Excludes != nil {
+			return *f.Excludes
+		}
+	case *IntFlag:
+		if f.Excludes != nil {
+			return *f.Excludes
+		}
+	case *Int64Flag:
+		if f.Excludes != nil {
+			return *f.Excludes
+		}
+	case *Float64Flag:
+		if f.Excludes != nil {
+			return *f.Excludes
+		}
+	case *StringSliceFlag:
+		if f.Excludes != nil {
+			return *f.Excludes
+		}
+	case *IntSliceFlag:
+		if f.Excludes != nil {
+			return *f.Excludes
+		}
+	case *Int64SliceFlag:
+		if f.Excludes != nil {
+			return *f.Excludes
+		}
+	case *Float64SliceFlag:
+		if f.Excludes != nil {
+			return *f.Excludes
+		}
+	case *BoolSliceFlag:
+		if f.Excludes != nil {
+			return *f.Excludes
+		}
+	}
+	return nil
+}

--- a/ra_dump_test.go
+++ b/ra_dump_test.go
@@ -1,0 +1,390 @@
+package ra
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDumpParseOrError(t *testing.T) {
+	t.Setenv("RA_COLOR", "auto")
+
+	cmd := NewCmd("testapp")
+	cmd.SetDescription("Test application")
+
+	inputFlag, err := NewString("input").
+		SetShort("i").
+		SetUsage("Input file path").
+		Register(cmd)
+	assert.NoError(t, err)
+
+	err = cmd.ParseOrError([]string{"test.txt"}, WithDump(true))
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, DumpInvokedErr))
+	assert.Equal(t, "", *inputFlag)
+}
+
+func TestDumpParseOrExit(t *testing.T) {
+	t.Setenv("RA_COLOR", "auto")
+
+	cmd := NewCmd("testapp")
+	cmd.SetDescription("Test application")
+
+	_, err := NewString("input").
+		SetShort("i").
+		SetUsage("Input file path").
+		Register(cmd)
+	assert.NoError(t, err)
+
+	var stdout bytes.Buffer
+	SetStdoutWriter(&stdout)
+	defer SetStdoutWriter(os.Stdout)
+
+	var exitCalled bool
+	var exitCode int
+	SetExitFunc(func(code int) {
+		exitCalled = true
+		exitCode = code
+	})
+	defer SetExitFunc(os.Exit)
+
+	args := []string{"--input", "test.txt"}
+	cmd.ParseOrExit(args, WithDump(true))
+
+	assert.True(t, exitCalled)
+	assert.Equal(t, 0, exitCode)
+
+	expected := `Ra Command Dump
+==================================================
+
+Parse Configuration:
+  Ignore Unknown: false
+  Dump Enabled: true
+
+Command Information:
+  Name: testapp
+  Description: Test application
+  Help Enabled: true
+  Auto Help on No Args: false
+  Exclude Name from Usage: false
+  Custom Usage Function: not set
+  PostParse Hook: not set
+  Subcommands: none
+
+Arguments to Parse:
+  [0]: "--input"
+  [1]: "test.txt"
+
+Flags Structure:
+  Total Flags: 2
+  Positional Flags: 1
+  Non-Positional Flags: 1
+  Global Flags: 1
+
+  Positional Flags (in order):
+    [0] input (-i) type:string required usage:"Input file path"
+
+  Non-Positional Flags:
+    help (-h) type:bool optional flags:[flag-only] usage:"Print usage string."
+
+  Global Flags:
+    help (-h) type:bool optional flags:[flag-only] usage:"Print usage string."
+
+Environment:
+  RA_COLOR: auto
+`
+
+	assert.Equal(t, expected, stdout.String())
+}
+
+func TestDumpWithSubcommands(t *testing.T) {
+	t.Setenv("RA_COLOR", "auto")
+
+	parent := NewCmd("parent")
+	parent.SetDescription("Parent command")
+
+	_, err := NewBool("global").
+		SetShort("g").
+		SetUsage("Global flag").
+		Register(parent, WithGlobal(true))
+	assert.NoError(t, err)
+
+	// First subcommand with a grandchild
+	sub := NewCmd("sub")
+	sub.SetDescription("Subcommand")
+
+	_, err = NewString("local").
+		SetShort("l").
+		SetUsage("Local flag").
+		Register(sub)
+	assert.NoError(t, err)
+
+	// Grandchild under first subcommand
+	grandchild := NewCmd("grandchild")
+	grandchild.SetDescription("Grandchild command")
+
+	_, err = NewInt("count").
+		SetShort("c").
+		SetUsage("Count value").
+		SetDefault(42).
+		Register(grandchild)
+	assert.NoError(t, err)
+
+	_, err = sub.RegisterCmd(grandchild)
+	assert.NoError(t, err)
+
+	// Second subcommand
+	sub2 := NewCmd("sub2")
+	sub2.SetDescription("Second subcommand")
+
+	_, err = NewBool("enabled").
+		SetShort("e").
+		SetUsage("Enable feature").
+		SetDefault(true).
+		Register(sub2)
+	assert.NoError(t, err)
+
+	subUsed, err := parent.RegisterCmd(sub)
+	assert.NoError(t, err)
+
+	_, err = parent.RegisterCmd(sub2)
+	assert.NoError(t, err)
+
+	var stdout bytes.Buffer
+	SetStdoutWriter(&stdout)
+	defer SetStdoutWriter(os.Stdout)
+
+	var exitCalled bool
+	SetExitFunc(func(code int) { exitCalled = true })
+	defer SetExitFunc(os.Exit)
+
+	parent.ParseOrExit([]string{}, WithDump(true))
+
+	assert.True(t, exitCalled)
+	assert.False(t, *subUsed)
+
+	expected := `Ra Command Dump
+==================================================
+
+Parse Configuration:
+  Ignore Unknown: false
+  Dump Enabled: true
+
+Command Information:
+  Name: parent
+  Description: Parent command
+  Help Enabled: true
+  Auto Help on No Args: false
+  Exclude Name from Usage: false
+  Custom Usage Function: not set
+  PostParse Hook: not set
+  Subcommands (2): sub, sub2
+
+Arguments to Parse:
+  <no arguments>
+
+Flags Structure:
+  Total Flags: 2
+  Positional Flags: 0
+  Non-Positional Flags: 2
+  Global Flags: 2
+
+  Non-Positional Flags:
+    global (-g) type:bool optional (default:false) flags:[flag-only] usage:"Global flag"
+    help (-h) type:bool optional flags:[flag-only] usage:"Print usage string."
+
+  Global Flags:
+    global (-g) type:bool optional (default:false) flags:[flag-only] usage:"Global flag"
+    help (-h) type:bool optional flags:[flag-only] usage:"Print usage string."
+
+Environment:
+  RA_COLOR: auto
+
+Subcommand Details:
+==================================================
+
+  Subcommand Dump (sub)
+  ------------------------------
+
+  Parse Configuration:
+    Ignore Unknown: false
+    Dump Enabled: true
+
+  Command Information:
+    Name: sub
+    Description: Subcommand
+    Help Enabled: true
+    Auto Help on No Args: false
+    Exclude Name from Usage: false
+    Custom Usage Function: not set
+    PostParse Hook: not set
+    Subcommands (1): grandchild
+
+  Flags Structure:
+    Total Flags: 2
+    Positional Flags: 1
+    Non-Positional Flags: 1
+    Global Flags: 1
+
+    Positional Flags (in order):
+      [0] local (-l) type:string required usage:"Local flag"
+
+    Non-Positional Flags:
+      global (-g) type:bool optional (default:false) flags:[flag-only] usage:"Global flag"
+
+    Global Flags:
+      global (-g) type:bool optional (default:false) flags:[flag-only] usage:"Global flag"
+
+    Subcommand Dump (grandchild)
+    ------------------------------
+
+    Parse Configuration:
+      Ignore Unknown: false
+      Dump Enabled: true
+
+    Command Information:
+      Name: grandchild
+      Description: Grandchild command
+      Help Enabled: true
+      Auto Help on No Args: false
+      Exclude Name from Usage: false
+      Custom Usage Function: not set
+      PostParse Hook: not set
+      Subcommands: none
+
+    Flags Structure:
+      Total Flags: 1
+      Positional Flags: 1
+      Non-Positional Flags: 0
+      Global Flags: 0
+
+      Positional Flags (in order):
+        [0] count (-c) type:int optional (default:42) usage:"Count value"
+
+
+  Subcommand Dump (sub2)
+  ------------------------------
+
+  Parse Configuration:
+    Ignore Unknown: false
+    Dump Enabled: true
+
+  Command Information:
+    Name: sub2
+    Description: Second subcommand
+    Help Enabled: true
+    Auto Help on No Args: false
+    Exclude Name from Usage: false
+    Custom Usage Function: not set
+    PostParse Hook: not set
+    Subcommands: none
+
+  Flags Structure:
+    Total Flags: 2
+    Positional Flags: 0
+    Non-Positional Flags: 2
+    Global Flags: 1
+
+    Non-Positional Flags:
+      enabled (-e) type:bool optional (default:true) current:false usage:"Enable feature"
+      global (-g) type:bool optional (default:false) flags:[flag-only] usage:"Global flag"
+
+    Global Flags:
+      global (-g) type:bool optional (default:false) flags:[flag-only] usage:"Global flag"
+
+`
+
+	assert.Equal(t, expected, stdout.String())
+}
+
+func TestDumpWithComplexFlags(t *testing.T) {
+	t.Setenv("RA_COLOR", "auto")
+
+	cmd := NewCmd("complex")
+
+	_, err := NewString("input").
+		SetShort("i").
+		SetUsage("Input file").
+		SetEnumConstraint([]string{"json", "xml"}).
+		Register(cmd)
+	assert.NoError(t, err)
+
+	_, err = NewInt("count").
+		SetShort("c").
+		SetUsage("Count").
+		SetDefault(10).
+		SetMin(1, false).
+		SetMax(100, true).
+		Register(cmd)
+	assert.NoError(t, err)
+
+	_, err = NewStringSlice("tags").
+		SetShort("t").
+		SetUsage("Tags").
+		SetVariadic(true).
+		Register(cmd)
+	assert.NoError(t, err)
+
+	var stdout bytes.Buffer
+	SetStdoutWriter(&stdout)
+	defer SetStdoutWriter(os.Stdout)
+
+	var exitCalled bool
+	SetExitFunc(func(code int) { exitCalled = true })
+	defer SetExitFunc(os.Exit)
+
+	cmd.ParseOrExit([]string{"--input", "json", "--count", "5", "tag1"}, WithDump(true))
+
+	assert.True(t, exitCalled)
+
+	expected := `Ra Command Dump
+==================================================
+
+Parse Configuration:
+  Ignore Unknown: false
+  Dump Enabled: true
+
+Command Information:
+  Name: complex
+  Description: <not set>
+  Help Enabled: true
+  Auto Help on No Args: false
+  Exclude Name from Usage: false
+  Custom Usage Function: not set
+  PostParse Hook: not set
+  Subcommands: none
+
+Arguments to Parse:
+  [0]: "--input"
+  [1]: "json"
+  [2]: "--count"
+  [3]: "5"
+  [4]: "tag1"
+
+Flags Structure:
+  Total Flags: 4
+  Positional Flags: 3
+  Non-Positional Flags: 1
+  Global Flags: 1
+
+  Positional Flags (in order):
+    [0] input (-i) type:string{json,xml} required usage:"Input file"
+    [1] count (-c) type:int(1,100] optional (default:10) current:10 usage:"Count"
+    [2] tags (-t) type:[]string(variadic) required usage:"Tags"
+
+  Non-Positional Flags:
+    help (-h) type:bool optional flags:[flag-only] usage:"Print usage string."
+
+  Global Flags:
+    help (-h) type:bool optional flags:[flag-only] usage:"Print usage string."
+
+Environment:
+  RA_COLOR: auto
+`
+
+	assert.Equal(t, expected, stdout.String())
+}

--- a/ra_opt.go
+++ b/ra_opt.go
@@ -21,6 +21,7 @@ func WithBypassValidation(b bool) RegisterOption {
 
 type parseCfg struct {
 	ignoreUnknown bool
+	dump          bool
 }
 
 type ParseOpt func(*parseCfg)
@@ -28,5 +29,11 @@ type ParseOpt func(*parseCfg)
 func WithIgnoreUnknown(ignore bool) ParseOpt {
 	return func(c *parseCfg) {
 		c.ignoreUnknown = ignore
+	}
+}
+
+func WithDump(dump bool) ParseOpt {
+	return func(c *parseCfg) {
+		c.dump = dump
 	}
 }


### PR DESCRIPTION
Users can set up complex Cmd structures, and it can be hard to communicate all their details for debugging.

Let's build in a 'dump opt' which, on parse, creates a dump of the entire cmd structure, allowing people (or LLMs) to read these back and recreate the scenario.