### PR TITLE
feat: add variadic unknown flags support

### DIFF
--- a/ra_opt.go
+++ b/ra_opt.go
@@ -20,8 +20,9 @@ func WithBypassValidation(b bool) RegisterOption {
 }
 
 type parseCfg struct {
-	ignoreUnknown bool
-	dump          bool
+	ignoreUnknown        bool
+	variadicUnknownFlags bool
+	dump                 bool
 }
 
 type ParseOpt func(*parseCfg)
@@ -29,6 +30,12 @@ type ParseOpt func(*parseCfg)
 func WithIgnoreUnknown(ignore bool) ParseOpt {
 	return func(c *parseCfg) {
 		c.ignoreUnknown = ignore
+	}
+}
+
+func WithVariadicUnknownFlags(enable bool) ParseOpt {
+	return func(c *parseCfg) {
+		c.variadicUnknownFlags = enable
 	}
 }
 


### PR DESCRIPTION
Enables variadic flags to collect unknown flags when WithVariadicUnknownFlags(true) is used. Unknown flags are collected into the current variadic argument until a known flag is encountered.