### PR TITLE
feat: extend short flag counts to int64, fix single case

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -84,13 +84,12 @@ mycmd -abc ddd  # last flag 'c' is a non-bool and so will read 'ddd'
 
 ## Incrementing int shorts
 
-- Always treat these as normal int args, with int behavior.
-- Only changes:
-  - If short flag specified at the end, even once, it does not require an arg; its value will be its count.
-  - If specified 2 or more times in a cluster, we will not try to parse the *next* arg as part of the int arg.
+Int and Int64 flags support clustered short flag counting:
+- When the same short flag is repeated (e.g., `-vvv`), the value is set to the count of repetitions
+- Explicit values override counting (e.g., `-vvv=10` sets value to 10, not 3)
+- Later occurrences override earlier ones (e.g., `-vv -v 5` sets value to 5)
 
-^^ TODO maybe not... maybe we just need an IsCounter toggle which makes it never interact with neighboring args
-
+**Basic counting:**
 ```sh
 mycmd -aaa
 ```
@@ -99,24 +98,43 @@ mycmd -aaa
 |-------------------------------------|-------|
 | `arg1: int`, short `a`, default `0` | `3`   |
 
+**Single flag with explicit value:**
 ```sh
 mycmd -a 3
 ```
 
 | Declared Arg                        | Value |
 |-------------------------------------|-------|
-| `arg1: int`, short `a`, default `0` | ?     |
-| `arg2: str`                         | ?     |
+| `arg1: int`, short `a`, default `0` | `3`   |
 
+**Counting with two repetitions:**
 ```sh
-mycmd -aa 3
+mycmd -aa
 ```
 
 | Declared Arg                        | Value |
 |-------------------------------------|-------|
-| `arg1: int`, short `a`, default `0` | ?     |
-| `arg2: str`                         | ?     |
+| `arg1: int`, short `a`, default `0` | `2`   |
 
+**Explicit value overrides counting:**
+```sh
+mycmd -aaa=10
+```
+
+| Declared Arg                        | Value |
+|-------------------------------------|-------|
+| `arg1: int`, short `a`, default `0` | `10`  |
+
+**Int64 flags work the same way:**
+```sh
+mycmd -nnn
+```
+
+| Declared Arg                          | Value |
+|---------------------------------------|-------|
+| `arg1: int64`, short `n`, default `0` | `3`   |
+
+**Error case - non-integer value:**
 ```sh
 mycmd -a bbb
 ```

--- a/ra_test.go
+++ b/ra_test.go
@@ -731,6 +731,80 @@ func Test_ExampleIncrementingIntShorts(t *testing.T) {
 	assert.Equal(t, 3, *arg1)
 }
 
+// Test int shorts with double clusters (later overrides earlier)
+func Test_IntShortsCounting_DoubleClusters(t *testing.T) {
+	fs := NewCmd("mycmd")
+
+	arg1, _ := NewInt("arg1").SetShort("a").SetDefault(0).Register(fs)
+
+	// -a -aaa should result in 3 (last cluster wins)
+	err := fs.ParseOrError([]string{"-a", "-aaa"})
+	assert.Nil(t, err)
+	assert.Equal(t, 3, *arg1)
+}
+
+// Example: mycmd -n -nnn (incrementing int64 shorts)
+func Test_ExampleIncrementingInt64Shorts(t *testing.T) {
+	fs := NewCmd("mycmd")
+
+	arg1, _ := NewInt64("arg1").SetShort("n").SetDefault(int64(0)).Register(fs)
+
+	// Test counting with -nnn
+	err := fs.ParseOrError([]string{"-n", "-nnn"})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(3), *arg1)
+}
+
+// Test that later occurrences override earlier ones for int64 counting
+func Test_Int64ShortsCounting_LaterOverridesEarlier(t *testing.T) {
+	fs := NewCmd("mycmd")
+
+	arg1, _ := NewInt64("arg1").SetShort("n").SetDefault(int64(0)).Register(fs)
+
+	// -nn -n should result in 1 (last occurrence wins)
+	err := fs.ParseOrError([]string{"-nn", "-n", "5"})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(5), *arg1)
+}
+
+// Test int64 shorts counting with various cluster sizes
+func Test_Int64ShortsCounting_VariousSizes(t *testing.T) {
+	fs := NewCmd("mycmd")
+
+	arg1, _ := NewInt64("arg1").SetShort("v").Register(fs)
+
+	// Single flag
+	err := fs.ParseOrError([]string{"-v", "10"})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(10), *arg1)
+
+	// Double flag
+	fs = NewCmd("mycmd")
+	arg1, _ = NewInt64("arg1").SetShort("v").Register(fs)
+	err = fs.ParseOrError([]string{"-vv"})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(2), *arg1)
+
+	// Five flags
+	fs = NewCmd("mycmd")
+	arg1, _ = NewInt64("arg1").SetShort("v").Register(fs)
+	err = fs.ParseOrError([]string{"-vvvvv"})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(5), *arg1)
+}
+
+// Test int64 shorts counting with equals override
+func Test_Int64ShortsCounting_WithEqualsOverride(t *testing.T) {
+	fs := NewCmd("mycmd")
+
+	arg1, _ := NewInt64("arg1").SetShort("v").Register(fs)
+
+	// -vvv=10 should use the explicit value 10, not count
+	err := fs.ParseOrError([]string{"-vvv=10"})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(10), *arg1)
+}
+
 // Example: mycmd -1 --arg2 -2 -3.4 (negative numbers without number shorts mode)
 func Test_ExampleNegativeNumbers(t *testing.T) {
 	fs := NewCmd("mycmd")


### PR DESCRIPTION
The '-vvv' example where that returns '3' for an int flag with short 'v', only worked for Int, not Int64.

While here we also fix the case '-v -vvv'. Here we want the value '3' again, since last cluster wins, but this would fail as it'd try to interpret '-vvv' as an int arg to the '-v' flag preceding it.

'-vv -vvv' would work correctly, because it'd not expect the next think after '-vv' to be a flag, but this should (arguably) also apply to a single '-v'. It's a bit debateable because it arguably leaves too much room for error.

A consequence of this change is that "myscript -v" is valid and returns '1' for 'v'. We might need to change this in the future, if we find users find to too easy to make errors with.